### PR TITLE
fix broken url '/item/15733760'

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,7 +6,7 @@
     "public": "dist/static",
     "rewrites": [
       {
-        "source": "/@(news|newest|show|ask|jobs)",
+        "source": "/@(news|newest|show|ask|jobs|item)",
         "function": "server"
       },
       {


### PR DESCRIPTION
In ASK page, url '/item?id=15733760' leads to 404.html whereas '/item/15733760' works ok.