### PR TITLE
fix(css): add missing vendor prefix for sticky positioning

### DIFF
--- a/src/build/css/stories.css
+++ b/src/build/css/stories.css
@@ -40,6 +40,7 @@
     align-items: center;
     justify-content: space-between;
     padding: 1rem 1.1rem;
+    position: -webkit-sticky;
     position: sticky;
     top: 0;
     background-color: rgb(255, 255, 255);


### PR DESCRIPTION
In my last PR I missed a little line for more information see here: https://github.com/davideast/hnpwa-firebase/issues/18#issuecomment-414133898