### PR TITLE
fix(css): fix width of two-digit item numbers

### DIFF
--- a/src/build/css/stories.css
+++ b/src/build/css/stories.css
@@ -6,7 +6,8 @@
 
 .hn-sr {
     padding: 15px;
-    width: 60px;
+    text-align: right;
+    width: 85px;
 }
 
 .hn-sr h2 {


### PR DESCRIPTION
This HN app has become my daily driver for it's speed and PWA features.

There is one little design issue: If the item number has two digits it overlaps the headline on desktop viewports as you can see in the appended screenshot.

This PR is my suggestion to fix this behavior, @davideast what do you think?

left: before, right: after

![screenshot 2019-02-13 at 10 51 18 am](https://user-images.githubusercontent.com/7473880/52702853-55e50280-2f7d-11e9-9581-8d89775a18d4.png)
