### PR TITLE
fix(css): fix width of two-digit item numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,14 @@
     "firebase-tools": "^3.9.1",
     "hnpwa-api": "^0.1.5",
     "lighthouse": "^2.1.0",
-    "lighthouse-ci": "https://github.com/ebidel/lighthouse-ci"
+    "lighthouse-ci": "https://github.com/ebidel/lighthouse-ci",
+    "rimraf": "^3.0.0"
   },
   "scripts": {
     "test": "echo \"lol tests\" && exit 0",
     "tsc": "node_modules/.bin/tsc -p src/server/tsconfig.json && node_modules/.bin/tsc -p src/build/tsconfig.json",
     "tsc:watch": "node_modules/.bin/tsc -p src/server/tsconfig.json -w",
-    "build:clean": "rm -rf dist",
+    "build:clean": "rimraf dist",
     "build": "npm run build:clean && npm run tsc && node dist/build/build.js",
     "serve": "npm run tsc && API_BASE=https://hnpwa.com/api/v0 node dist/build/offline.server",
     "serve:firebase": "npm run tsc && firebase serve --only functions,hosting",

--- a/src/build/css/stories.css
+++ b/src/build/css/stories.css
@@ -6,7 +6,8 @@
 
 .hn-sr {
     padding: 15px;
-    width: 60px;
+    text-align: right;
+    width: 85px;
 }
 
 .hn-sr h2 {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2277,6 +2277,18 @@ glob@^7.0.0, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.3:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 global-dirs@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
@@ -4571,6 +4583,13 @@ rimraf@2.6.1:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
     glob "^7.0.5"
+
+rimraf@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
+  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
+  dependencies:
+    glob "^7.1.3"
 
 router@^1.3.1:
   version "1.3.2"


### PR DESCRIPTION
This PR fixes the display (width & alignment) of two-digit item numbers.

It also replaces the *nix-style rm command using the cross-platform compatible `rimraf`module as a devDependency as suggested in the comments of the corresponding issue.

Fixes #20