### PR TITLE
Add a bottom/footer pager for easier navigation

### DIFF
--- a/src/build/index.html
+++ b/src/build/index.html
@@ -48,6 +48,8 @@
 
       </section>
 
+      <!-- ::PAGER:: -->
+
     </div>
     <script defer src="/sw.reg.js"></script>
   </body>

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -82,7 +82,7 @@ async function createStoryPage(topic: string, page: string, stories: any[]) {
   const storiesIndex = styledIndex.replace('<!-- ::STORIES:: -->', storyHtml);  
   const { next, back, nextPositive, current, maxedOut } = getPagerOptions(topic, page);
   const pageHtml = pagerTemplate({ topic, next, back, nextPositive, current, maxedOut });
-  return storiesIndex.replace('<!-- ::PAGER:: -->', pageHtml);
+  return storiesIndex.replace(/<!-- ::PAGER:: -->/g, pageHtml);
 }
 
 /**


### PR DESCRIPTION
# Proposed Changes

I browse this site using my phone and I'm normally holding it in one hand. I have found it quite frustrating to navigate to the next/previous pages. The problem is that my thumb never quite reaches very high up the screen. But the pager sits almost all the way at the top of the screen. So I have added a pager to the bottom of the screen to make navigation a bit easier.

# Screenshots

![Screen Shot 2020-03-13 at 6 59 02 pm](https://user-images.githubusercontent.com/18509578/76597506-1fe9c780-655d-11ea-842f-e11f2059aad9.png)

![Screen Shot 2020-03-13 at 6 59 29 pm](https://user-images.githubusercontent.com/18509578/76597510-224c2180-655d-11ea-9f63-0a19073d6410.png)
 